### PR TITLE
Add multilingual validation

### DIFF
--- a/examples/config_multilingual_nanoset.yaml
+++ b/examples/config_multilingual_nanoset.yaml
@@ -1,5 +1,5 @@
 checkpoints:
-  checkpoint_interval: 1000
+  checkpoint_interval: 1000000
   checkpoints_path: checkpoints/
   checkpoints_path_is_shared_file_system: false
   resume_checkpoint_path: null
@@ -7,14 +7,34 @@ checkpoints:
 data_stages:
 - data:
     dataset:
-      training_folder: datasets/c4-es/train
-      validation_folder: datasets/c4-es/validation
+      training_folder:
+        datasets/c4-es/train: 0.85
+        datasets/c4-en/train: 0.05
+        datasets/c4-fr/train: 0.1
+      validation_folder:
+      - datasets/c4-es/validation
+      - datasets/c4-en/validation
+      - datasets/c4-fr/validation
+      lang_to_ids:
+        es: 128002
+        en: 128003
+        fr: 128004
+    num_loading_workers: 1
+    seed: 42
+  name: General purpose training (Blended dataset)
+  start_training_step: 1
+- data:
+    dataset:
+      training_folder:
+      - datasets/c4-es/train
+      validation_folder:
+      - datasets/c4-es/validation
       lang_to_ids:
         es: 128002
     num_loading_workers: 1
     seed: 42
-  name: General purpose training (Single dataset)
-  start_training_step: 1
+  name: Second purpose training (Single dataset)
+  start_training_step: 100
 - data:
     dataset:
       training_folder:
@@ -29,34 +49,16 @@ data_stages:
         es: 128002
         en: 128003
         fr: 128004
-    num_loading_workers: 1
-    seed: 42
-  name: Second purpose training (> 1 dataset)
-  start_training_step: 15
-- data:
-    dataset:
-      training_folder:
-        datasets/c4-es/train: 0.6
-        datasets/c4-en/train: 0.3
-        datasets/c4-fr/train: 0.1
-      validation_folder:
-      - datasets/c4-es/validation
-      - datasets/c4-en/validation
-      - datasets/c4-fr/validation
-      lang_to_ids:
-        es: 128002
-        en: 128003
-        fr: 128004
 
     num_loading_workers: 1
     seed: 42
-  name: Third purpose training (Blended dataset)
-  start_training_step: 25
+  name: Third purpose training (>1 dataset)
+  start_training_step: 200
 general:
   benchmark_csv_path: null
   consumed_train_samples: null
   ignore_sanity_checks: true
-  project: Nanoset
+  project: Multilingual
   run: llama
   seed: 42
   step: null
@@ -75,12 +77,12 @@ model:
     bos_token_id: 1
     eos_token_id: 2
     hidden_act: silu
-    hidden_size: 512
+    hidden_size: 4096
     initializer_range: 0.02
-    intermediate_size: 512
+    intermediate_size: 14336
     is_llama_config: true
-    max_position_embeddings: 1024
-    num_hidden_layers: 2
+    max_position_embeddings: 4096
+    num_hidden_layers: 32
     num_attention_heads: 32
     num_key_value_heads: 8
     pad_token_id: null
@@ -89,7 +91,7 @@ model:
     rope_theta: 500000.0
     rms_norm_eps: 1.0e-06
     rope_scaling: null
-    tie_word_embeddings: true
+    tie_word_embeddings: false
     use_cache: true
     vocab_size: 128256
 optimizer:
@@ -116,19 +118,19 @@ parallelism:
   expert_parallel_size: 1
   pp: 1
   pp_engine: 1f1b
-  tp: 1
+  tp: 4
   tp_linear_async_communication: false
   tp_mode: REDUCE_SCATTER
 profiler: null
 tokenizer:
   tokenizer_max_length: null
-  tokenizer_name_or_path: meta-llama/Meta-Llama-3-8B
+  tokenizer_name_or_path: /mloscratch/homes/solergib/models/Meta-Llama-3-8B
   tokenizer_revision: null
 tokens:
   batch_accumulation_per_replica: 1
   limit_test_batches: 0
   limit_val_batches: 10
-  micro_batch_size: 4
-  sequence_length: 1024
-  train_steps: 200
-  val_check_interval: 3
+  micro_batch_size: 3
+  sequence_length: 4096
+  train_steps: 800
+  val_check_interval: 50

--- a/examples/config_multilingual_nanoset.yaml
+++ b/examples/config_multilingual_nanoset.yaml
@@ -131,4 +131,4 @@ tokens:
   micro_batch_size: 4
   sequence_length: 1024
   train_steps: 200
-  val_check_interval: -1
+  val_check_interval: 3

--- a/examples/config_multilingual_nanoset.yaml
+++ b/examples/config_multilingual_nanoset.yaml
@@ -8,17 +8,17 @@ data_stages:
 - data:
     dataset:
       training_folder:
-        datasets/c4-es/train: 0.85
-        datasets/c4-en/train: 0.05
-        datasets/c4-fr/train: 0.1
+      - datasets/c4-es/train
+      - datasets/c4-en/train
+      - datasets/c4-fr/train
       validation_folder:
       - datasets/c4-es/validation
       - datasets/c4-en/validation
       - datasets/c4-fr/validation
-      lang_to_ids:
-        es: 128002
-        en: 128003
-        fr: 128004
+      languages:
+      - es
+      - en
+      - fr
     num_loading_workers: 1
     seed: 42
   name: General purpose training (Blended dataset)
@@ -29,12 +29,12 @@ data_stages:
       - datasets/c4-es/train
       validation_folder:
       - datasets/c4-es/validation
-      lang_to_ids:
-        es: 128002
+      languages:
+      - es
     num_loading_workers: 1
     seed: 42
   name: Second purpose training (Single dataset)
-  start_training_step: 100
+  start_training_step: 1000
 - data:
     dataset:
       training_folder:
@@ -45,20 +45,19 @@ data_stages:
       - datasets/c4-es/validation
       - datasets/c4-en/validation
       - datasets/c4-fr/validation
-      lang_to_ids:
-        es: 128002
-        en: 128003
-        fr: 128004
-
+      languages:
+      - es
+      - en
+      - fr
     num_loading_workers: 1
     seed: 42
   name: Third purpose training (>1 dataset)
-  start_training_step: 200
+  start_training_step: 2000
 general:
   benchmark_csv_path: null
   consumed_train_samples: null
   ignore_sanity_checks: true
-  project: Multilingual
+  project: MultilingualV2
   run: llama
   seed: 42
   step: null
@@ -114,7 +113,7 @@ optimizer:
   weight_decay: 0.01
   zero_stage: 0
 parallelism:
-  dp: 1
+  dp: 2
   expert_parallel_size: 1
   pp: 1
   pp_engine: 1f1b
@@ -132,5 +131,5 @@ tokens:
   limit_val_batches: 10
   micro_batch_size: 3
   sequence_length: 4096
-  train_steps: 800
-  val_check_interval: 50
+  train_steps: 500
+  val_check_interval: 100

--- a/examples/config_multilingual_nanoset.yaml
+++ b/examples/config_multilingual_nanoset.yaml
@@ -124,7 +124,7 @@ parallelism:
 profiler: null
 tokenizer:
   tokenizer_max_length: null
-  tokenizer_name_or_path: /mloscratch/homes/solergib/models/Meta-Llama-3-8B
+  tokenizer_name_or_path: meta-llama/Meta-Llama-3-8B
   tokenizer_revision: null
 tokens:
   batch_accumulation_per_replica: 1

--- a/run_train.py
+++ b/run_train.py
@@ -194,7 +194,6 @@ def get_dataloader_from_data_stage(
                 sequence_length=trainer.sequence_length,
                 token_size=token_size,
                 train_split_num_samples=trainer.config.tokens.train_steps * trainer.global_batch_size,
-                dataset_tokens=data.dataset.dataset_tokens,
                 random_seed=data.seed,
             )
 
@@ -209,6 +208,7 @@ def get_dataloader_from_data_stage(
             consumed_train_samples=consumed_train_samples,
             dataloader_num_workers=data.num_loading_workers,
             dataloader_drop_last=True,
+            is_multilingual=True,
         )
 
         return train_dataloader
@@ -241,7 +241,6 @@ def get_valid_dataloader_from_data_stage(
                 dataset_folders=data.dataset.validation_folder,
                 sequence_length=trainer.sequence_length,
                 token_size=token_size,
-                dataset_tokens=data.dataset.dataset_tokens,
                 is_valid=True,
                 random_seed=data.seed,
             )
@@ -257,6 +256,7 @@ def get_valid_dataloader_from_data_stage(
             dataloader_num_workers=data.num_loading_workers,
             dataloader_drop_last=True,
             shuffle=True,
+            is_multilingual=True,
         )
 
         return valid_dataloader

--- a/run_train.py
+++ b/run_train.py
@@ -238,10 +238,10 @@ def get_valid_dataloader_from_data_stage(
 
         with main_rank_first(trainer.parallel_context.world_pg):
             valid_dataset = MultilingualNanoset(
-                dataset_folders=data.dataset.validation_folder,  # TODO Just 1 folder
+                dataset_folders=data.dataset.validation_folder,
                 sequence_length=trainer.sequence_length,
                 token_size=token_size,
-                dataset_tokens=data.dataset.dataset_tokens,  # TODO Just 1 lang
+                dataset_tokens=data.dataset.dataset_tokens,
                 is_valid=True,
                 random_seed=data.seed,
             )
@@ -331,9 +331,12 @@ def get_valid_dataloader(trainer: DistributedTrainer) -> Dict[str, DataLoader]:
         # the validation MultilingualNanoset info (Number of samples, etc.) [UPDATE: ]. In order to solve that, we could get rid of this lambda
         # funcs and directly create all dataloaders.
         #
-        # This lambda functs (Used in training too) are for creating the DataLoaders lazyly FOR 1. Start training faster instead of creating multiple DataLoaders
-        # 2. Consume less memory as the lambda func is lighter that the DataLoader object with the Dataset, collator, etc.
-        # BUT 1. The Nanoset creation process is very fast and 2. Nanosets doesn't consume any memory at all till we start sampling from the Nanoset
+        # This lambda functs (Used in training too) are for creating the DataLoaders lazyly FOR 1. Start training faster instead
+        # of creating multiple DataLoaders 2. Consume less memory as the lambda func is lighter that the DataLoader object with
+        # the Dataset, collator, etc.
+        # BUT 1. The Nanoset creation process is very fast and 2. Nanosets doesn't consume any memory at all till we start sampling
+        # from the Nanoset. Also they later transform the DataLoader into a Iterator object so it's impossible to retrieve
+        # the DataLoader object again to delete it (More comments in trainer.py)
         dataloaders[stage.name] = dataloader
     return dataloaders
 

--- a/run_train.py
+++ b/run_train.py
@@ -325,8 +325,15 @@ def get_valid_dataloader(trainer: DistributedTrainer) -> Dict[str, DataLoader]:
         dataloader = (
             get_valid_dataloader_from_data_stage(trainer, stage.data)
             if stage_idx == 0
-            else lambda stage=stage: get_dataloader_from_data_stage(trainer, stage.data)
+            else lambda stage=stage: get_valid_dataloader_from_data_stage(trainer, stage.data)
         )
+        # TODO(tj.solergibert) As we are creating again the valid dataloader in every validation stage, we print multiple times
+        # the validation MultilingualNanoset info (Number of samples, etc.) [UPDATE: ]. In order to solve that, we could get rid of this lambda
+        # funcs and directly create all dataloaders.
+        #
+        # This lambda functs (Used in training too) are for creating the DataLoaders lazyly FOR 1. Start training faster instead of creating multiple DataLoaders
+        # 2. Consume less memory as the lambda func is lighter that the DataLoader object with the Dataset, collator, etc.
+        # BUT 1. The Nanoset creation process is very fast and 2. Nanosets doesn't consume any memory at all till we start sampling from the Nanoset
         dataloaders[stage.name] = dataloader
     return dataloaders
 

--- a/run_train.py
+++ b/run_train.py
@@ -238,10 +238,10 @@ def get_valid_dataloader_from_data_stage(
 
         with main_rank_first(trainer.parallel_context.world_pg):
             valid_dataset = MultilingualNanoset(
-                dataset_folders=data.dataset.validation_folder,
+                dataset_folders=data.dataset.validation_folder,  # TODO Just 1 folder
                 sequence_length=trainer.sequence_length,
                 token_size=token_size,
-                dataset_tokens=data.dataset.dataset_tokens,
+                dataset_tokens=data.dataset.dataset_tokens,  # TODO Just 1 lang
                 is_valid=True,
                 random_seed=data.seed,
             )

--- a/run_train.py
+++ b/run_train.py
@@ -256,6 +256,7 @@ def get_valid_dataloader_from_data_stage(
             micro_batch_size=trainer.micro_batch_size,
             dataloader_num_workers=data.num_loading_workers,
             dataloader_drop_last=True,
+            shuffle=True,
         )
 
         return valid_dataloader
@@ -315,7 +316,7 @@ def get_valid_dataloader(trainer: DistributedTrainer) -> Dict[str, DataLoader]:
         stage = cast(DatasetStageArgs, stage)
 
         log_rank(
-            f"[Validation Plan] Stage {stage.name} has {len(stage.data.dataset.validation_folder)} folders with samples in the validation set",
+            f"[Validation Plan] Stage {stage.name} has {len(stage.data.dataset.validation_folder)} folders with samples for the validation set",
             logger=logger,
             level=logging.INFO,
             rank=0,

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -125,6 +125,7 @@ class MultilingualNanosetDatasetsArgs:
             self.training_folder = list(tmp_training_folder.keys())
             self.dataset_weights = list(tmp_training_folder.values())
 
+        self.ids_to_lang = {v: k for k, v in self.lang_to_ids.items()}
         self.dataset_tokens = list(self.lang_to_ids.values())
         assert len(self.training_folder) == len(
             self.validation_folder

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -111,7 +111,7 @@ class NanosetDatasetsArgs:
 class MultilingualNanosetDatasetsArgs:
     training_folder: Union[str, dict, List[str]]
     validation_folder: Union[str, List[str]]
-    lang_to_ids: dict  # Mapping from the previously defined folders to tokens. Respect the order
+    languages: List[str]  # NOTE(tj.solergibert) Required for 1. Aggregating the result 2. Reporting to WANDB
 
     def __post_init__(self):
         if isinstance(self.training_folder, str):  # Case 1: 1 Dataset folder
@@ -125,14 +125,13 @@ class MultilingualNanosetDatasetsArgs:
             self.training_folder = list(tmp_training_folder.keys())
             self.dataset_weights = list(tmp_training_folder.values())
 
-        self.ids_to_lang = {v: k for k, v in self.lang_to_ids.items()}
-        self.dataset_tokens = list(self.lang_to_ids.values())
+        assert len(self.training_folder) == len(
+            self.languages
+        ), f"The sizes of training_folder and languages mismatch ({len(self.training_folder)} vs {len(self.languages)})"
+
         assert len(self.training_folder) == len(
             self.validation_folder
         ), f"The sizes of training_folder and validation_folder mismatch ({len(self.training_folder)} vs {len(self.validation_folder)})"
-        assert len(self.training_folder) == len(
-            self.dataset_tokens
-        ), f"The sizes of training_folder and lang_to_ids mismatch ({len(self.training_folder)} vs {len(self.dataset_tokens)})"
 
 
 @dataclass

--- a/src/nanotron/config/config.py
+++ b/src/nanotron/config/config.py
@@ -406,6 +406,13 @@ class Config:
                 for i in range(len(self.data_stages) - 1)
             ), "The stages are not sorted by start_training_step in increasing order"
 
+        # NOTE(tj.solergibert) As we are reporting the training & validation metrics together, we
+        # must comply with val_check_interval % iteration_step_info_interval = 0
+        if not self.tokens.val_check_interval % self.logging.iteration_step_info_interval == 0:
+            raise ValueError(
+                f"It is necessary to run the validation stage during a logging step. Validation interval: {self.tokens.val_check_interval}, Logging interval: {self.logging.iteration_step_info_interval}"
+            )
+
         # # if lighteval, we need tokenizer to be defined
         # if self.checkpoints.lighteval is not None:
         #     assert self.tokenizer.tokenizer_name_or_path is not None

--- a/src/nanotron/data/collator.py
+++ b/src/nanotron/data/collator.py
@@ -78,3 +78,76 @@ class NanosetDataCollatorForCLM:
             )
 
         return result
+
+
+@dataclasses.dataclass
+class MultilingualNanosetDataCollatorForCLM:
+    """
+    Data collator used for causal language modeling with Nanosets dataset.
+
+    - input_pp_rank: Discards last input id token
+    - output_pp_rank: Discards first label id token
+    - other pp ranks: Don't have data. Instead, we use `TensorPointer` to point to the rank having the data.
+    """
+
+    sequence_length: int
+    input_pp_rank: int
+    output_pp_rank: int
+    parallel_context: ParallelContext
+
+    def __call__(self, examples: List[Dict[str, List[np.ndarray]]]) -> Dict[str, Union[torch.Tensor, TensorPointer]]:
+        # Process the case when current rank doesn't require data. We return `TensorPointer` that points to ranks having the data.
+        current_pp_rank = dist.get_rank(self.parallel_context.pp_pg)
+        if current_pp_rank not in [
+            self.input_pp_rank,
+            self.output_pp_rank,
+        ]:
+            assert all(len(example) == 0 for example in examples)
+            return {
+                "input_ids": TensorPointer(group_rank=self.input_pp_rank),
+                "input_mask": TensorPointer(group_rank=self.input_pp_rank),
+                "lang_code": TensorPointer(group_rank=self.input_pp_rank),
+                "label_ids": TensorPointer(group_rank=self.output_pp_rank),
+                "label_mask": TensorPointer(group_rank=self.output_pp_rank),
+            }
+
+        # TODO @nouamanetazi: Is it better to have examples as np.array or torch.Tensor?
+        input_ids = torch.vstack([examples[i]["input_ids"] for i in range(len(examples))])  # (b, s)
+        lang_code = torch.vstack([examples[i]["lang_code"] for i in range(len(examples))])  # (b, 1)
+        batch_size, expanded_input_length = input_ids.shape
+
+        result: Dict[str, Union[torch.LongTensor, TensorPointer]] = {}
+
+        result["input_ids"] = TensorPointer(group_rank=self.input_pp_rank)
+        result["input_mask"] = TensorPointer(group_rank=self.input_pp_rank)
+        result["lang_code"] = TensorPointer(group_rank=self.input_pp_rank)
+        result["label_ids"] = TensorPointer(group_rank=self.output_pp_rank)
+        result["label_mask"] = TensorPointer(group_rank=self.output_pp_rank)
+
+        assert (
+            expanded_input_length == self.sequence_length + 1
+        ), f"Samples should be of length {self.sequence_length + 1} (seq_len+1), but got {expanded_input_length}"
+
+        # Process inputs: last token is the label
+        if current_pp_rank == self.input_pp_rank:
+            result["input_ids"] = input_ids[:, :-1]
+            result["input_mask"] = torch.ones((batch_size, self.sequence_length), dtype=torch.bool)
+            result["lang_code"] = lang_code
+
+        # Process labels: shift them to the left
+        if current_pp_rank == self.output_pp_rank:
+            result["label_ids"] = input_ids[:, 1:]
+            result["label_mask"] = torch.ones((batch_size, self.sequence_length), dtype=torch.bool)
+
+        if isinstance(result["input_ids"], torch.Tensor) and result["input_ids"].shape[-1] != self.sequence_length:
+            raise ValueError(
+                f"`labels` are incorrectly preprocessed. `labels` length is {result['input_ids'].shape[-1]}, but should be"
+                f" {self.sequence_length}."
+            )
+        if isinstance(result["label_ids"], torch.Tensor) and result["label_ids"].shape[-1] != self.sequence_length:
+            raise ValueError(
+                f"`labels` are incorrectly preprocessed. `labels` length is {result['label_ids'].shape[-1]}, but should be"
+                f" {self.sequence_length}."
+            )
+
+        return result

--- a/src/nanotron/data/dataloader_builder.py
+++ b/src/nanotron/data/dataloader_builder.py
@@ -1,6 +1,6 @@
 import nanotron.distributed as dist
 from nanotron import logging
-from nanotron.data.collator import NanosetDataCollatorForCLM
+from nanotron.data.collator import MultilingualNanosetDataCollatorForCLM, NanosetDataCollatorForCLM
 from nanotron.dataloader import (
     EmptyInfiniteDataset,
     get_dataloader_worker_init,
@@ -20,6 +20,7 @@ def build_nanoset_dataloader(
     output_pp_rank: int,
     micro_batch_size: int,
     dataloader_num_workers: int,
+    is_multilingual: bool = False,
     consumed_train_samples: int = 0,
     dataloader_drop_last: bool = True,
     dataloader_pin_memory: bool = True,
@@ -39,6 +40,14 @@ def build_nanoset_dataloader(
         output_pp_rank=output_pp_rank,
         parallel_context=parallel_context,
     )
+
+    if is_multilingual:
+        data_collator = MultilingualNanosetDataCollatorForCLM(
+            sequence_length=sequence_length,
+            input_pp_rank=input_pp_rank,
+            output_pp_rank=output_pp_rank,
+            parallel_context=parallel_context,
+        )
 
     # Compute size and rank of dataloader workers
     dp_ranks_size = parallel_context.dp_pg.size()

--- a/src/nanotron/data/dataloader_builder.py
+++ b/src/nanotron/data/dataloader_builder.py
@@ -23,6 +23,7 @@ def build_nanoset_dataloader(
     consumed_train_samples: int = 0,
     dataloader_drop_last: bool = True,
     dataloader_pin_memory: bool = True,
+    shuffle: bool = False,
 ) -> DataLoader:
 
     # Case of ranks not requiring data. We give them a dummy dataset, then the collator will do his job
@@ -49,7 +50,7 @@ def build_nanoset_dataloader(
         dl_rank=dp_rank,
         drop_last=dataloader_drop_last,
         consumed_train_samples=consumed_train_samples,
-        shuffle=False,
+        shuffle=shuffle,
     )
 
     return DataLoader(

--- a/src/nanotron/data/multilingual_nanoset.py
+++ b/src/nanotron/data/multilingual_nanoset.py
@@ -30,7 +30,6 @@ class MultilingualNanoset(torch.utils.data.Dataset):
         dataset_folders: List[str],
         sequence_length: int,
         token_size: int,
-        dataset_tokens: List[int],
         train_split_num_samples: int = None,
         is_valid: bool = False,
         dataset_weights: Union[List[float], None] = None,
@@ -47,7 +46,6 @@ class MultilingualNanoset(torch.utils.data.Dataset):
         self.sequence_length = sequence_length
         self.token_size = token_size
         self.train_split_num_samples = train_split_num_samples
-        self.dataset_tokens = dataset_tokens
         self.is_valid = is_valid
         self.random_seed = random_seed
         self.datatrove_datasets = []
@@ -107,7 +105,7 @@ class MultilingualNanoset(torch.utils.data.Dataset):
         dataset_sample = self.dataset_sample_index[idx]
 
         tokens = self.datatrove_datasets[dataset][dataset_sample]
-        tokens["input_ids"][0] = self.dataset_tokens[dataset]  # Prepend language token
+        tokens["lang_code"] = torch.tensor(dataset, dtype=torch.long)
 
         return tokens
 

--- a/src/nanotron/distributed.py
+++ b/src/nanotron/distributed.py
@@ -52,10 +52,6 @@ def all_gather_into_tensor(  # pylint: disable=function-redefined
     if group is None:
         group = dist.torch_dist.distributed_c10d._get_default_group()
 
-    assert (
-        group.size() > 1
-    ), "You should probably not call `all_gather_into_tensor` with a single rank, as it copies data over"
-
     if torch_version_above_1_13:
         return dist.all_gather_into_tensor(
             output_tensor=output_tensor, input_tensor=input_tensor, group=group, async_op=async_op

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -825,8 +825,10 @@ class Loss(nn.Module):
         ).transpose(0, 1)
         # TODO @thomasw21: It's unclear what kind of normalization we want to do.
         sample_loss = masked_mean(sample_loss, label_mask, dtype=torch.float)
-        # NOTE @tj.solergibert: masked_mean returns a single scalar with the batch loss. We've changed it to compute the SAMPLE loss.
+        # NOTE(tj.solergibert) masked_mean returns a single scalar with the batch loss. We've changed it to compute the SAMPLE loss.
         # We will continue using "loss" as the batch loss but we add "sample_loss" for the multilingual effort.
+        # WARN(tj.solergibert) Don't panic, the batch loss used to update the parameters is computed in `LlamaForTraining`
+
         # TODO @thomasw21: I think indexing causes a sync we don't actually want
         # TODO @thomasw21: loss = loss[label_mask].sum()
         return {"sample_loss": sample_loss}

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -803,12 +803,7 @@ def masked_mean(loss, label_mask, dtype):
     # type: (Tensor, Tensor, torch.dtype) -> Tensor
     return (loss * label_mask).sum(dim=1, dtype=dtype) / label_mask.sum(
         dim=1
-    )  # TODO esto de entrada da float/float = float
-
-
-# TODO la loss de cada uno !!!! ((loss * label_mask).sum(dim=1, dtype=dtype) / label_mask.sum(dim=1))
-# Y pasa el assert close!!
-# assert_close(((loss * label_mask).sum(dtype=dtype) / label_mask.sum()), torch.mean((loss * label_mask).sum(dim=1, dtype=dtype) / label_mask.sum(dim=1)))
+    )  # NOTE(tj.solergibert) Added dim=1 to return a tensor with shape [Batch size, 1] instead of [1]
 
 
 class Loss(nn.Module):

--- a/src/nanotron/parallel/pipeline_parallel/engine.py
+++ b/src/nanotron/parallel/pipeline_parallel/engine.py
@@ -140,7 +140,7 @@ class PipelineEngine(ABC):
         self.nb_microbatches = nb_microbatches
 
         outputs = []
-        lang_ids = []
+        lang_codes = []
 
         with attach_pipeline_state_to_model(model=model, pipeline_state=state):
             # All forward
@@ -166,9 +166,9 @@ class PipelineEngine(ABC):
                 outputs.extend(
                     list(output["sample_loss"])
                 )  # NOTE(tj.solergibert) Yes, it might look useless to do list + extend but it's necessary to split the output["sample_loss"] tensor into multiple tensors
-                lang_ids.extend(micro_batch["input_ids"][:, 0].tolist())
+                lang_codes.extend(micro_batch["lang_code"].flatten().tolist())
 
-        return outputs, lang_ids
+        return outputs, lang_codes
 
 
 class AllForwardAllBackwardPipelineEngine(PipelineEngine):

--- a/src/nanotron/parallel/pipeline_parallel/engine.py
+++ b/src/nanotron/parallel/pipeline_parallel/engine.py
@@ -12,7 +12,7 @@ from nanotron.logging import log_rank
 from nanotron.optim.gradient_accumulator import GradientAccumulator
 from nanotron.parallel.data_parallel.utils import ddp_trigger_sync_in_bwd
 from nanotron.parallel.pipeline_parallel.context_manager import attach_pipeline_state_to_model
-from nanotron.parallel.pipeline_parallel.state import PipelineTrainBatchState
+from nanotron.parallel.pipeline_parallel.state import PipelineEvalBatchState, PipelineTrainBatchState
 from nanotron.parallel.pipeline_parallel.tensor_pointer import TensorPointer
 from nanotron.utils import ContextManagers
 
@@ -136,7 +136,7 @@ class PipelineEngine(ABC):
         nb_microbatches: int,
     ) -> Iterable[Dict[str, Union[torch.Tensor, TensorPointer]]]:
         # Assign a new state for the current batch
-        state = PipelineTrainBatchState()  # TODO: do i need state?
+        state = PipelineEvalBatchState()  # PipelineTrainBatchState()  # TODO: do i need state?
         self.nb_microbatches = nb_microbatches
 
         outputs = []

--- a/src/nanotron/parallel/pipeline_parallel/state.py
+++ b/src/nanotron/parallel/pipeline_parallel/state.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import List
 
 import torch
+
 from nanotron import distributed as dist
 from nanotron import logging
 from nanotron.logging import log_rank
@@ -202,6 +203,9 @@ class PipelineEvalBatchState(PipelineBatchState):
     microbatches_activations_to_send = collections.deque()
     microbatches_activations_to_recv = collections.deque()
     activations_buffer = collections.deque()
+
+    # Reinitialise counter
+    nb_forwards = 0
 
     def register_activation_requiring_backward(self, activation: torch.Tensor):
         pass

--- a/src/nanotron/serialize/metadata.py
+++ b/src/nanotron/serialize/metadata.py
@@ -46,6 +46,8 @@ class TrainingMetadata:
     last_stage_idx: Optional[int] = None
     data_stages: Optional[List[DataStageMetadata]] = None
 
+    last_validation_stage_idx: Optional[int] = None
+
     def __post_init__(self):
         # NOTE: this is a sanity check after loading a trained checkpoint
         total_consumed_samples_across_stages = sum(stage.consumed_train_samples for stage in self.data_stages)

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -730,12 +730,12 @@ class DistributedTrainer:
             validation_elapsed_time_per_iteration_ms = (self.validation_step_time - self.training_step_time) * 1000
             validation_tokens_per_sec = (
                 validation_total_samples * self.sequence_length / (validation_elapsed_time_per_iteration_ms / 1000)
-            )  # tokens_per_sec is calculated using sequence_length
+            )
 
             validation_model_tflops, validation_hardware_tflops = self.unwrapped_model.get_flops_per_sec(
                 iteration_time_in_sec=validation_elapsed_time_per_iteration_ms / 1000,
                 sequence_length=self.sequence_length,
-                global_batch_size=validation_total_samples,  # TODO con esto de la global batch size yo la pondria a 1 y multiplicaba por el numero de batches
+                global_batch_size=validation_total_samples,
             )
 
         if dist.get_rank(self.parallel_context.world_pg) in self.logger_ranks:


### PR DESCRIPTION
In this PR I include the validation stage per languages! There are some comments in the code itself, but the most relevant things to take care of are:
- The validation stage DataLoaders are crafted with the same logic nanotron implemented the training ones with the different training stages([`_update_dataloader_based_on_training_stages`](https://github.com/TJ-Solergibert/nanotron/blob/d75038dad4ba8786344f06725b24b213059f9b97/src/nanotron/trainer.py#L409) for training and [`_prepare_dataloader_for_validation_stage`](https://github.com/TJ-Solergibert/nanotron/blob/d75038dad4ba8786344f06725b24b213059f9b97/src/nanotron/trainer.py#L309C9-L309C49) for validation). After carefully analysing the mechanism, I have to contact them because it's not deleting the previous DataLoaders from the previous stages properly. Is it something we should be aware of? NO, everything works, but I copied this logic for the validation stage and it's kind of useless & messy. 
- When aggregating the different language losses there is one case where it fails: If we have a DP (Data Parallel) group with NO (0) SAMPLES from a language, it will try to all reduce this metric which is a empty list with all the other DP groups and will fail. I hope we don't run into this kind of issues, but I propose 1 (messy) solution to this problem we could try.

To use this validation stage feature you just need to set `dataset.validation_folder` for each data stage and `tokens. val_check_interval`. Be aware that as we are logging the training & validation metrics together, we must set the validation interval a multiple of the logging interval (aka perform the validation stage during a training step in which we are logging the metrics).

You can check some wandb logs [here](https://wandb.ai/tj-solergibert/Multilingual/workspace?nw=nwusertjsolergibert). Keep in mind that wand logs each metric separately, so in order to merge in a single plot the different language losses + global loss you need to "edit panel" (✏️) and set in the `*` option "validation_loss". I recommend you trying this feature with a single wandb run instead of the whole project runs.